### PR TITLE
feat(html): add meta tags, favicon links, and Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,25 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>devutils-pwa</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/devutils-icon.svg" />
+  <link rel="apple-touch-icon" href="/devutils-icon-192.png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#6366F1" />
+  <title>DevUtils — Developer Utilities. Fast. Private. In Your Browser.</title>
+  <meta name="description"
+    content="Format JSON. Generate test data. Decode JWT. Privacy-first developer tools that run entirely in your browser." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Fira+Code:wght@400;500&display=swap"
+    rel="stylesheet" />
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>


### PR DESCRIPTION
## What
Updated index.html with production-ready meta and font configuration.

## Changes
- Added favicon and apple-touch-icon links
- Added theme-color meta tag (#6366F1)
- Updated page title with full SEO title
- Added meta description for search engines
- Added Google Fonts preconnect for Inter and Fira Code
- Added Google Fonts stylesheet link

## Why
Improves SEO, browser tab appearance, PWA icon display, 
and ensures fonts load correctly in production.

## Breaking Changes
None