### PR TITLE
fix(deps): patch flatted vulnerability via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4362,9 +4362,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Description

Patched high severity vulnerability in flatted (<3.4.0) 
via npm audit fix.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] My code follows the project's style and conventions
- [x] I have tested my changes locally
- [x] All existing tests pass (`npx vitest run`)
- [x] The build succeeds (`npm run build`)
- [x] This works client-side only — no server calls

## Vulnerability Fixed

flatted <3.4.0
Severity: high
Unbounded recursion DoS in parse() revive phase
https://github.com/advisories/GHSA-25h7-pfq9-p65f