### PR TITLE
docs(readme): fix tech stack — remove Tailwind, clarify vanilla CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 | Framework | [React 19](https://react.dev/) with functional components & hooks |
 | Language | [TypeScript 5.9](https://www.typescriptlang.org/) |
 | Build Tool | [Vite 7](https://vite.dev/) |
-| Styling | [Tailwind CSS 4](https://tailwindcss.com/) + vanilla CSS custom properties |
+| Styling | Vanilla CSS with custom properties (CSS variables) |
 | Routing | [React Router 7](https://reactrouter.com/) |
 | Icons | [Lucide React](https://lucide.dev/) |
 | PWA | [vite-plugin-pwa](https://vite-pwa-org.netlify.app/) (Workbox) |


### PR DESCRIPTION
## Description

Fixed incorrect tech stack entry in README. 
Project uses vanilla CSS with custom properties, not Tailwind CSS.

## Type of Change

- [x] 📝 Documentation update

## Checklist

- [x] My code follows the project's style and conventions
- [x] I have tested my changes locally
- [x] All existing tests pass (`npx vitest run`)
- [x] The build succeeds (`npm run build`)
- [x] This works client-side only — no server calls