### PR TITLE
feat: add Base64 encoder/decoder tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
-        "vite-plugin-pwa": "^1.2.0"
+        "vite-plugin-pwa": "^1.2.0",
+        "vitest": "^4.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2736,6 +2737,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -2793,6 +2801,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3206,6 +3232,149 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3306,6 +3475,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -3545,6 +3724,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3925,6 +4114,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4157,19 +4353,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -4239,6 +4422,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5658,6 +5851,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5799,6 +6003,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6384,6 +6595,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6457,6 +6675,20 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6673,6 +6905,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6688,6 +6937,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tr46": {
@@ -7106,6 +7365,98 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -7228,6 +7579,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "vitest": "^4.1.0"
   },
   "overrides": {
     "serialize-javascript": ">=7.0.3"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import JwtDecoder from './pages/JwtDecoder';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import TermsOfService from './pages/TermsOfService';
 import Contributing from './pages/Contributing';
+import Base64Tool from "./pages/Base64Tool";
 
 export default function App() {
     return (
@@ -28,6 +29,7 @@ export default function App() {
                                 <Route path="/privacy-policy" element={<PrivacyPolicy />} />
                                 <Route path="/terms-of-service" element={<TermsOfService />} />
                                 <Route path="/contributing" element={<Contributing />} />
+                                <Route path="/base64" element={<Base64Tool />} />
                             </Routes>
                         </main>
                         <Footer />

--- a/src/__tests__/base64Utils.test.ts
+++ b/src/__tests__/base64Utils.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from 'vitest';
+import { encodeBase64, decodeBase64 } from '../utils/base64Utils';
+
+describe('base64Utils', () => {
+
+  describe('encodeBase64', () => {
+
+    test('encodes standard ASCII strings correctly', () => {
+      expect(encodeBase64('Hello World')).toBe('SGVsbG8gV29ybGQ=');
+    });
+
+    test('encodes Unicode/Emojis correctly (UTF-8)', () => {
+      expect(encodeBase64('🚀 orbit')).toBe('8J+agCBvcmJpdA==');
+      expect(encodeBase64('你好')).toBe('5L2g5aW9');
+    });
+
+    test('encodes to URL-safe format when requested', () => {
+      const input = 'Subject? Data+';
+      const encoded = encodeBase64(input, true);
+
+      expect(encoded).not.toContain('+');
+      expect(encoded).not.toContain('/');
+      expect(encoded).not.toContain('=');
+      expect(encoded).toBe('U3ViamVjdD8gRGF0YSs');
+    });
+
+    test('handles empty string', () => {
+      expect(encodeBase64('')).toBe('');
+    });
+
+  });
+
+  describe('decodeBase64', () => {
+
+    test('decodes standard Base64 strings', () => {
+      expect(decodeBase64('SGVsbG8gV29ybGQ=')).toBe('Hello World');
+    });
+
+    test('decodes Unicode/Emoji Base64 strings', () => {
+      expect(decodeBase64('8J+agCBvcmJpdA==')).toBe('🚀 orbit');
+      expect(decodeBase64('5L2g5aW9')).toBe('你好');
+    });
+
+    test('decodes URL-safe strings (with or without padding)', () => {
+      const urlSafeInput = 'U3ViamVjdD8gRGF0YSs';
+      expect(decodeBase64(urlSafeInput)).toBe('Subject? Data+');
+    });
+
+    test('handles empty string', () => {
+      expect(decodeBase64('')).toBe('');
+    });
+
+    test('throws error for invalid Base64', () => {
+      expect(() => decodeBase64('!!!NotBase64!!!')).toThrow();
+    });
+
+  });
+
+  describe('Round-trip Integrity', () => {
+
+    test('maintains data integrity through encode → decode cycle', () => {
+      const complexString =
+        'Special characters: !@#$%^&*()_+ []{} | ";: <>,.?/ and Emojis: 🧠🔥';
+
+      const encoded = encodeBase64(complexString);
+      const decoded = decodeBase64(encoded);
+
+      expect(decoded).toBe(complexString);
+    });
+
+  });
+
+});

--- a/src/__tests__/base64Utils.test.ts
+++ b/src/__tests__/base64Utils.test.ts
@@ -1,20 +1,20 @@
-import { describe, test, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { encodeBase64, decodeBase64 } from '../utils/base64Utils';
 
 describe('base64Utils', () => {
 
   describe('encodeBase64', () => {
 
-    test('encodes standard ASCII strings correctly', () => {
+    it('encodes standard ASCII strings correctly', () => {
       expect(encodeBase64('Hello World')).toBe('SGVsbG8gV29ybGQ=');
     });
 
-    test('encodes Unicode/Emojis correctly (UTF-8)', () => {
+    it('encodes Unicode/Emojis correctly (UTF-8)', () => {
       expect(encodeBase64('🚀 orbit')).toBe('8J+agCBvcmJpdA==');
       expect(encodeBase64('你好')).toBe('5L2g5aW9');
     });
 
-    test('encodes to URL-safe format when requested', () => {
+    it('encodes to URL-safe format when requested', () => {
       const input = 'Subject? Data+';
       const encoded = encodeBase64(input, true);
 
@@ -24,7 +24,7 @@ describe('base64Utils', () => {
       expect(encoded).toBe('U3ViamVjdD8gRGF0YSs');
     });
 
-    test('handles empty string', () => {
+    it('handles empty string', () => {
       expect(encodeBase64('')).toBe('');
     });
 
@@ -32,29 +32,29 @@ describe('base64Utils', () => {
 
   describe('decodeBase64', () => {
 
-    test('decodes standard Base64 strings', () => {
+    it('decodes standard Base64 strings', () => {
       expect(decodeBase64('SGVsbG8gV29ybGQ=')).toBe('Hello World');
     });
 
-    test('decodes Unicode/Emoji Base64 strings', () => {
+    it('decodes Unicode/Emoji Base64 strings', () => {
       expect(decodeBase64('8J+agCBvcmJpdA==')).toBe('🚀 orbit');
       expect(decodeBase64('5L2g5aW9')).toBe('你好');
     });
 
-    test('decodes URL-safe strings (with or without padding)', () => {
+    it('decodes URL-safe strings (with or without padding)', () => {
       const urlSafeInput = 'U3ViamVjdD8gRGF0YSs';
       expect(decodeBase64(urlSafeInput)).toBe('Subject? Data+');
     });
 
-    test('handles empty string', () => {
+    it('handles empty string', () => {
       expect(decodeBase64('')).toBe('');
     });
 
-    test('throws error for invalid Base64', () => {
+    it('throws error for invalid Base64', () => {
       expect(() => decodeBase64('!!!NotBase64!!!')).toThrow("Invalid Base64 string");
     });
 
-    test('handles whitespace around Base64 input', () => {
+    it('handles whitespace around Base64 input', () => {
       expect(decodeBase64(' SGVsbG8gV29ybGQ= ')).toBe('Hello World');
     });
 
@@ -62,7 +62,7 @@ describe('base64Utils', () => {
 
   describe('Round-trip Integrity', () => {
 
-    test('maintains data integrity through encode → decode cycle', () => {
+    it('maintains data integrity through encode → decode cycle', () => {
       const complexString =
         'Special characters: !@#$%^&*()_+ []{} | ";: <>,.?/ and Emojis: 🧠🔥';
 

--- a/src/__tests__/base64Utils.test.ts
+++ b/src/__tests__/base64Utils.test.ts
@@ -51,7 +51,11 @@ describe('base64Utils', () => {
     });
 
     test('throws error for invalid Base64', () => {
-      expect(() => decodeBase64('!!!NotBase64!!!')).toThrow();
+      expect(() => decodeBase64('!!!NotBase64!!!')).toThrow("Invalid Base64 string");
+    });
+
+    test('handles whitespace around Base64 input', () => {
+      expect(decodeBase64(' SGVsbG8gV29ybGQ= ')).toBe('Hello World');
     });
 
   });

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ const allTools = [
     { to: '/json-formatter', label: 'JSON Formatter', description: 'Validate, format, and minify JSON data' },
     { to: '/dummy-data', label: 'Dummy Data Generator', description: 'Generate random user data for testing' },
     { to: '/jwt-decoder', label: 'JWT Decoder', description: 'Decode and inspect JSON Web Tokens' },
+    { to: '/base64', label: 'Base64 Encoder / Decoder', description: 'Encode text to Base64 or decode Base64 strings in your browser' },
 ];
 
 const navLinks = allTools.map(t => ({ to: t.to, label: t.label.replace(' Generator', '') }));

--- a/src/pages/Base64Tool.tsx
+++ b/src/pages/Base64Tool.tsx
@@ -58,15 +58,47 @@ export default function Base64Tool() {
   return (
     <div className="container" style={{ paddingTop: 32, paddingBottom: 40 }}>
       
-      {/* Header */}
-      <div style={{ marginBottom: 12 }}>
-        <h2 style={{ fontSize: 22, fontWeight: 700 }}>
-          Base64 Encoder / Decoder
-        </h2>
-        <p style={{ fontSize: 13, color: "var(--color-text-secondary)" }}>
-          Encode text to Base64 or decode Base64 strings directly in your browser.
-        </p>
-      </div>
+        {/* Header */}
+        <div
+        style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "flex-start",
+            marginBottom: 8,
+            flexWrap: "wrap",
+            gap: 12
+        }}
+        >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8, flexWrap: 'wrap', gap: 12 }}>
+            <div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
+                    <h2 style={{ fontSize: 22, fontWeight: 700 }}>Base64 Encoder / Decoder</h2>
+                    <span className="badge badge-primary">CLIENT-SIDE</span>
+                </div>
+                <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>
+                    Encode text to Base64 or decode Base64 strings directly in your browser.
+                </p>
+            </div>
+        </div>
+
+        <div style={{ display: "flex", gap: 8 }}>
+            <button
+            className="btn btn-primary"
+            onClick={handleEncode}
+            style={{ padding: "8px 16px", fontSize: 13 }}
+            >
+            Encode
+            </button>
+
+            <button
+            className="btn btn-secondary"
+            onClick={handleDecode}
+            style={{ padding: "8px 16px", fontSize: 13 }}
+            >
+            Decode
+            </button>
+        </div>
+        </div>
 
       {/* Editor Layout */}
       <div className="tool-layout">
@@ -74,9 +106,11 @@ export default function Base64Tool() {
         {/* Input Panel */}
         <div className="tool-panel">
           <div className="tool-panel-header">
-            <span>Input</span>
+            <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-text-secondary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                Input
+            </span>
             <div style={{ flex: 1 }} />
-            <button className="btn btn-ghost" onClick={handleClear}>
+            <button className="btn btn-ghost" onClick={handleClear} aria-label="Clear input" style={{ fontSize: 12, padding: '4px 10px' }}>
               <Trash2 size={12}/> Clear
             </button>
           </div>
@@ -95,7 +129,9 @@ export default function Base64Tool() {
         {/* Output Panel */}
         <div className="tool-panel">
           <div className="tool-panel-header">
-            <span>Output</span>
+            <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-text-secondary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                Output
+            </span>
 
             {error && (
               <span className="status-pill status-error">
@@ -104,21 +140,11 @@ export default function Base64Tool() {
             )}
 
             <div style={{ flex: 1 }} />
-
-            <button
-              className="btn btn-ghost"
-              onClick={handleCopy}
-              disabled={!output}
-            >
-              <Copy size={12}/> {copied ? "Copied!" : "Copy"}
+            <button className="btn btn-ghost" onClick={handleCopy} disabled={!output} aria-label="Copy output" style={{ fontSize: 12, padding: '4px 10px' }}>
+                <Copy size={12} /> {copied ? 'Copied!' : 'Copy'}
             </button>
-
-            <button
-              className="btn btn-ghost"
-              onClick={handleDownload}
-              disabled={!output}
-            >
-              <Download size={12}/> Download
+            <button className="btn btn-ghost" onClick={handleDownload} disabled={!output} aria-label="Download output" style={{ fontSize: 12, padding: '4px 10px' }}>
+                <Download size={12} /> Download
             </button>
           </div>
 
@@ -132,17 +158,6 @@ export default function Base64Tool() {
             />
           </div>
         </div>
-      </div>
-
-      {/* Action Buttons */}
-      <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
-        <button className="btn btn-primary" onClick={handleEncode}>
-          Encode
-        </button>
-
-        <button className="btn btn-secondary" onClick={handleDecode}>
-          Decode
-        </button>
       </div>
     </div>
   );

--- a/src/pages/Base64Tool.tsx
+++ b/src/pages/Base64Tool.tsx
@@ -60,44 +60,45 @@ export default function Base64Tool() {
       
         {/* Header */}
         <div
-        style={{
+          style={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "flex-start",
             marginBottom: 8,
             flexWrap: "wrap",
             gap: 12
-        }}
+          }}
         >
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8, flexWrap: 'wrap', gap: 12 }}>
-            <div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
-                    <h2 style={{ fontSize: 22, fontWeight: 700 }}>Base64 Encoder / Decoder</h2>
-                    <span className="badge badge-primary">CLIENT-SIDE</span>
-                </div>
-                <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>
-                    Encode text to Base64 or decode Base64 strings directly in your browser.
-                </p>
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 4 }}>
+              <h2 style={{ fontSize: 22, fontWeight: 700 }}>
+                Base64 Encoder / Decoder
+              </h2>
+              <span className="badge badge-primary">CLIENT-SIDE</span>
             </div>
-        </div>
 
-        <div style={{ display: "flex", gap: 8 }}>
+            <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', margin: 0 }}>
+              Encode text to Base64 or decode Base64 strings directly in your browser.
+            </p>
+          </div>
+
+          <div style={{ display: "flex", gap: 8 }}>
             <button
-            className="btn btn-primary"
-            onClick={handleEncode}
-            style={{ padding: "8px 16px", fontSize: 13 }}
+              className="btn btn-primary"
+              onClick={handleEncode}
+              style={{ padding: "8px 16px", fontSize: 13 }}
             >
-            Encode
+              Encode
             </button>
 
             <button
-            className="btn btn-secondary"
-            onClick={handleDecode}
-            style={{ padding: "8px 16px", fontSize: 13 }}
+              className="btn btn-secondary"
+              onClick={handleDecode}
+              style={{ padding: "8px 16px", fontSize: 13 }}
             >
-            Decode
+              Decode
             </button>
-        </div>
+          </div>
         </div>
 
       {/* Editor Layout */}

--- a/src/pages/Base64Tool.tsx
+++ b/src/pages/Base64Tool.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { Copy, Download, Trash2 } from "lucide-react";
+import { encodeBase64, decodeBase64 } from "../utils/base64Utils";
+
+export default function Base64Tool() {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleEncode = () => {
+    try {
+      const result = encodeBase64(input);
+      setOutput(result);
+      setError(null);
+    } catch {
+      setError("Encoding failed.");
+    }
+  };
+
+  const handleDecode = () => {
+    try {
+      const result = decodeBase64(input);
+      setOutput(result);
+      setError(null);
+    } catch {
+      setError("Invalid Base64 string.");
+    }
+  };
+
+  const handleClear = () => {
+    setInput("");
+    setOutput("");
+    setError(null);
+  };
+
+  const handleCopy = async () => {
+    if (!output) return;
+    await navigator.clipboard.writeText(output);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  const handleDownload = () => {
+    if (!output) return;
+
+    const blob = new Blob([output], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "base64-output.txt";
+    a.click();
+
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="container" style={{ paddingTop: 32, paddingBottom: 40 }}>
+      
+      {/* Header */}
+      <div style={{ marginBottom: 12 }}>
+        <h2 style={{ fontSize: 22, fontWeight: 700 }}>
+          Base64 Encoder / Decoder
+        </h2>
+        <p style={{ fontSize: 13, color: "var(--color-text-secondary)" }}>
+          Encode text to Base64 or decode Base64 strings directly in your browser.
+        </p>
+      </div>
+
+      {/* Editor Layout */}
+      <div className="tool-layout">
+
+        {/* Input Panel */}
+        <div className="tool-panel">
+          <div className="tool-panel-header">
+            <span>Input</span>
+            <div style={{ flex: 1 }} />
+            <button className="btn btn-ghost" onClick={handleClear}>
+              <Trash2 size={12}/> Clear
+            </button>
+          </div>
+
+          <div className="tool-panel-body">
+            <textarea
+              className="code-editor"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Enter text or Base64..."
+              spellCheck={false}
+            />
+          </div>
+        </div>
+
+        {/* Output Panel */}
+        <div className="tool-panel">
+          <div className="tool-panel-header">
+            <span>Output</span>
+
+            {error && (
+              <span className="status-pill status-error">
+                {error}
+              </span>
+            )}
+
+            <div style={{ flex: 1 }} />
+
+            <button
+              className="btn btn-ghost"
+              onClick={handleCopy}
+              disabled={!output}
+            >
+              <Copy size={12}/> {copied ? "Copied!" : "Copy"}
+            </button>
+
+            <button
+              className="btn btn-ghost"
+              onClick={handleDownload}
+              disabled={!output}
+            >
+              <Download size={12}/> Download
+            </button>
+          </div>
+
+          <div className="tool-panel-body">
+            <textarea
+              className="code-editor"
+              value={output}
+              readOnly
+              placeholder="Result will appear here..."
+              spellCheck={false}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
+        <button className="btn btn-primary" onClick={handleEncode}>
+          Encode
+        </button>
+
+        <button className="btn btn-secondary" onClick={handleDecode}>
+          Decode
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/utils/base64Utils.ts
+++ b/src/utils/base64Utils.ts
@@ -19,7 +19,8 @@ export function encodeBase64(text: string, urlSafe: boolean = false): string {
 
 export function decodeBase64(base64: string): string {
   try {
-    let normalized = base64.replace(/-/g, "+").replace(/_/g, "/");
+    let cleaned = base64.trim();
+    let normalized = cleaned.replace(/-/g, "+").replace(/_/g, "/");
 
     while (normalized.length % 4 !== 0) {
       normalized += "=";

--- a/src/utils/base64Utils.ts
+++ b/src/utils/base64Utils.ts
@@ -1,0 +1,34 @@
+export function encodeBase64(text: string, urlSafe: boolean = false): string {
+  try {
+    const bytes = new TextEncoder().encode(text);
+    const binString = Array.from(bytes, (byte) => String.fromCodePoint(byte)).join("");
+    let encoded = btoa(binString);
+
+    if (urlSafe) {
+      encoded = encoded
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+    }
+
+    return encoded;
+  } catch {
+    throw new Error("Encoding failed: Input contains incompatible characters.");
+  }
+}
+
+export function decodeBase64(base64: string): string {
+  try {
+    let normalized = base64.replace(/-/g, "+").replace(/_/g, "/");
+
+    while (normalized.length % 4 !== 0) {
+      normalized += "=";
+    }
+
+    const binString = atob(normalized);
+    const bytes = Uint8Array.from(binString, (char) => char.codePointAt(0)!);
+    return new TextDecoder().decode(bytes);
+  } catch {
+    throw new Error("Invalid Base64 string: Ensure the input is correctly formatted.");
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
+    "types": ["vite/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,6 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client", "vitest/globals"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
## Description

Adds a **Base64 Encoder / Decoder tool** to the application.

This PR introduces utility functions for Base64 encoding and decoding, along with a dedicated UI page to allow users to encode text into Base64 or decode Base64 strings directly in the browser. All processing is performed client-side to maintain user privacy.

### Changes

* Added `encodeBase64` and `decodeBase64` utilities in `src/utils/base64Utils.ts`
* Added unit tests in `src/__tests__/base64Utils.test.ts`
* Created `Base64Tool` page for encoding and decoding Base64
* Added copy and download functionality for the output
* Ensured Unicode and emoji support using UTF-8 encoding

---

## Type of Change

* [ ] 🐛 Bug fix
* [x] ✨ New feature
* [ ] 📝 Documentation update
* [ ] ♻️ Refactor
* [ ] 🎨 Style / UI update

---

## Checklist

* [x] My code follows the project's style and conventions
* [x] I have tested my changes locally
* [x] All existing tests pass (`npx vitest run`)
* [x] I have added tests for new utilities (if applicable)
* [x] The build succeeds (`npm run build`)
* [x] This works client-side only — no server calls

---

## Screenshots (if UI change)

<img width="1919" height="1016" alt="image" src="https://github.com/user-attachments/assets/5bd3de66-dbbd-448e-a2ca-f03c6991b34f" />
